### PR TITLE
Update grok order when parsing risk list entities

### DIFF
--- a/parsers/standard_risklist.conf
+++ b/parsers/standard_risklist.conf
@@ -1,8 +1,8 @@
 # Product: Recorded Future
 # Category: IOC
 # Supported Format: JSON
-# Author: Jonah Feldman/Recorded Future
-# Last Updated: 2025-01-01
+# Author: Recorded Future
+# Last Updated: 2025-09-08
 
 filter {
   json {
@@ -88,47 +88,63 @@ filter {
   #Create event, create IOC if IP/Domain
   grok {
     match => {
-      "Value" => "%{IP:ip}"
+      Value => "%{URI:url}"
     }
-    on_error => "not_ip"
+    on_error => "not_url"
   }
-  if ![not_ip] {
+  if ![not_url]{
     mutate {
       replace => {
-        "event.ioc.feed_name" => "Recorded Future IOC"
-        "event.ioc.confidence_score" => "%{RiskScoreString}"
-        "event.ioc.raw_severity" => "%{RiskScoreString}"
-        "event.ioc.categorization" => "%{RiskRules}"
-        "event.ioc.ip_and_ports.ip_address" => "%{ip}"
-        "event.idm.entity.metadata.entity_type" => "IP_ADDRESS"
-
-      }
-    }
-
-    date {
-      match => ["Timestamps.StartTime","ISO8601"]
-      target => "event.ioc.active_timerange.start"
-    }
-    date {
-      match => ["Timestamps.EndTime","ISO8601"]
-      target => "event.ioc.active_timerange.end"
-    }
-
-    mutate {
-      convert => {
-        "event.ioc.ip_and_ports.ip_address" => "ipaddress"
-      }
-    }
-    mutate {
-      merge => {
-         "event.idm.entity.entity.ip" => "ip"
+        "event.idm.entity.entity.url" => "%{Value}"
+        "event.idm.entity.metadata.entity_type" => "URL"
       }
     }
   }
   else {
     grok {
+        match => {
+          "Value" => "%{IP:ip}"
+        }
+        on_error => "not_ip"
+      }
+      if ![not_ip] {
+        mutate {
+          replace => {
+            "event.ioc.feed_name" => "Recorded Future IOC"
+            "event.ioc.confidence_score" => "%{RiskScoreString}"
+            "event.ioc.raw_severity" => "%{RiskScoreString}"
+            "event.ioc.categorization" => "%{RiskRules}"
+            "event.ioc.ip_and_ports.ip_address" => "%{ip}"
+            "event.idm.entity.metadata.entity_type" => "IP_ADDRESS"
+
+          }
+        }
+
+        date {
+          match => ["Timestamps.StartTime","ISO8601"]
+          target => "event.ioc.active_timerange.start"
+        }
+        date {
+          match => ["Timestamps.EndTime","ISO8601"]
+          target => "event.ioc.active_timerange.end"
+        }
+
+        mutate {
+          convert => {
+            "event.ioc.ip_and_ports.ip_address" => "ipaddress"
+          }
+        }
+        mutate {
+          merge => {
+            "event.idm.entity.entity.ip" => "ip"
+          }
+        }
+      }
+    
+    else{
+      grok {
       match => {
-        Value => "(?P<Domain>^[0-9A-Za-z]+(?:\\.\\S+){1,})"
+        Value => "(?P<Domain>^[0-9A-Za-z-]+(?:\\.\\S+){1,})"
       }
       on_error => "not_domain"
     }
@@ -154,22 +170,6 @@ filter {
         target => "event.ioc.active_timerange.end"
       }
     }
-
-    else{
-      grok {
-        match => {
-          Value => "%{URI:url}"
-        }
-        on_error => "not_url"
-      }
-      if ![not_url]{
-        mutate {
-          replace => {
-            "event.idm.entity.entity.url" => "%{Value}"
-            "event.idm.entity.metadata.entity_type" => "URL"
-          }
-        }
-      }
       #parsing hash
       else {
         grok {

--- a/parsers/standard_risklist.conf
+++ b/parsers/standard_risklist.conf
@@ -85,7 +85,7 @@ filter {
     on_error => "risk_is_already_a string"
   }
 
-  #Create event, create IOC if IP/Domain
+  #Create event, create IOC if URL
   grok {
     match => {
       Value => "%{URI:url}"
@@ -100,6 +100,7 @@ filter {
       }
     }
   }
+  # Create IOC if IP
   else {
     grok {
         match => {
@@ -140,7 +141,7 @@ filter {
           }
         }
       }
-    
+    # Create IOC if Domain
     else{
       grok {
       match => {
@@ -170,7 +171,7 @@ filter {
         target => "event.ioc.active_timerange.end"
       }
     }
-      #parsing hash
+      # Create IOC if Hash
       else {
         grok {
           match => {


### PR DESCRIPTION
Fixes errors when parsing risk list entities
- Expands domain regex filter to match missing hyphen character
- Reorder entity parsing logic to account for most restrictive cases first